### PR TITLE
Use parameter expansion to set XDG base directories

### DIFF
--- a/please-use-xdg.sh
+++ b/please-use-xdg.sh
@@ -59,11 +59,11 @@
 # - Hex
 # - Mix
 # - NV
-[ -z "$XDG_DATA_HOME"   ] && export XDG_DATA_HOME="$HOME/.local/share"
-[ -z "$XDG_CONFIG_HOME" ] && export XDG_CONFIG_HOME="$HOME/.config"
-[ -z "$XDG_DATA_DIRS"   ] && export XDG_DATA_DIRS="/usr/local/share:/usr/share"
-[ -z "$XDG_CONFIG_DIRS" ] && export XDG_CONFIG_DIRS="/etc/xdg"
-[ -z "$XDG_CACHE_HOME"  ] && export XDG_CACHE_HOME="$HOME/.cache"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+export XDG_CONFIG_DIRS="${XDG_CONFIG_DIRS:-/etc/xdg}"
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_DATA_DIRS="${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 
 # Ack
 export ACKRC="$XDG_CONFIG_HOME/ack/ackrc"


### PR DESCRIPTION
Use POSIX parameter expansion to set the value for the XDG base directories to the defaults if they are unset instead of checking for the parameter and then exporting it only if unset. Seems cleaner but maybe that's just me.

I've also alphabetised the list of parameters because OCD :-)