### PR TITLE
Add new XDG_STATE_HOME variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ Maybe other, but I haven't tested it in other shells.
   + `$HOME/.hex/docs` -> `$XDG_DATA_HOME/hex/docs`
 - Less
   + `$HOME/.lesskey` -> `$XDG_CONFIG_HOME/less/lesskey`
-  + `$HOME/.lesshst` -> `$XDG_DATA_HOME/less/history`
+  + `$HOME/.lesshst` -> `$XDG_STATE_HOME/less/history`
 - Mathematica
   + `$HOME/.Mathematica` -> `$XDG_CONFIG_HOME/Mathematica`
 - Mix †
   + `$HOME/.mix/config.exs` -> `$XDG_CONFIG_HOME/mix/config.exs`
   + `$HOME/.mix/{archives,escripts}` -> `$XDG_DATA_HOME/mix`
 - Node.js
-  + `$HOME/.node_repl_history` -> `$XDG_DATA_HOME/node/repl_history`
+  + `$HOME/.node_repl_history` -> `$XDG_STATE_HOME/node/repl_history`
 - NotMuch
   + `$HOME/.notmuch-config` -> `$XDG_CONFIG_HOME/notmuch/config`
 - NV †
@@ -59,7 +59,7 @@ Maybe other, but I haven't tested it in other shells.
   + `$HOME/.parallel` -> `$XDG_CONFIG_HOME/parallel`
 - PostgreSQL
   + `$HOME/.psqlrc` -> `$XDG_CONFIG_HOME/postgres/rc`
-  + `$HOME/.psql_history` -> `$XDG_CACHE_HOME/postgres/history`
+  + `$HOME/.psql_history` -> `$XDG_STATE_HOME/postgres/history`
   + `$HOME/.pgpass` -> `$XDG_CONFIG_HOME/postgres/pass`
   + `$HOME/.pg_service.conf` -> `$XDG_CONFIG_HOME/postgres/service.conf`
 - Readline

--- a/please-use-xdg.sh
+++ b/please-use-xdg.sh
@@ -64,6 +64,7 @@
 [ -z "$XDG_CONFIG_HOME" ] && export XDG_CONFIG_HOME="$HOME/.config"
 [ -z "$XDG_DATA_DIRS"   ] && export XDG_DATA_DIRS="/usr/local/share:/usr/share"
 [ -z "$XDG_DATA_HOME"   ] && export XDG_DATA_HOME="$HOME/.local/share"
+[ -z "$XDG_STATE_HOME"   ] && export XDG_STATE_HOME="$HOME/.local/state"
 
 # Ack
 export ACKRC="$XDG_CONFIG_HOME/ack/ackrc"
@@ -97,13 +98,13 @@ export GNUPGHOME="$XDG_DATA_HOME/gnupg"
 
 # Less
 export LESSKEY="$XDG_CONFIG_HOME/less/lesskey" \
-  LESSHISTFILE="$XDG_DATA_HOME/less/history"
+  LESSHISTFILE="$XDG_STATE_HOME/less/history"
 
 # Mathematica
 export MATHEMATICA_USERBASE="$XDG_CONFIG_HOME/Mathematica"
 
 # Node.js
-export NODE_REPL_HISTORY="$XDG_DATA_HOME/node/repl_history"
+export NODE_REPL_HISTORY="$XDG_STATE_HOME/node/repl_history"
 
 # NotMuch
 export NOTMUCH_CONFIG="$XDG_CONFIG_HOME/notmuch/config"
@@ -116,7 +117,7 @@ export PARALLEL_HOME="$XDG_CONFIG_HOME/parallel"
 
 # PostgreSQL
 export PSQLRC="$XDG_CONFIG_HOME/postgres/rc" \
-  PSQL_HISTORY="$XDG_CACHE_HOME/postgres/history" \
+  PSQL_HISTORY="$XDG_STATE_HOME/postgres/history" \
   PGPASSFILE="$XDG_CONFIG_HOME/postgres/pass" \
   PGSERVICEFILE="$XDG_CONFIG_HOME/postgres/service.conf"
 # We need to create these directories if not exists


### PR DESCRIPTION
The basedir spec somewhat recently added XDG_STATE_HOME to account for things like history that are not cache, and not temporary, but alsö not config and alsö not data. The history file itself may need to last quite a long time, and arguably should still be backed up (not cache), but it is constantly in flux and would make zero sense in version control (not config).

Alsö, the Arch linux wiki has a ongoing list of whatsits: https://wiki.archlinux.org/title/XDG_Base_Directory